### PR TITLE
Fix typo in nandflash-jlink.qml

### DIFF
--- a/examples/sama5d2/nandflash/nandflash-jlink.qml
+++ b/examples/sama5d2/nandflash/nandflash-jlink.qml
@@ -2,7 +2,7 @@ import SAMBA 3.2
 import SAMBA.Connection.JLink 3.2
 import SAMBA.Device.SAMA5D2 3.2
 
-JlinkConnection {
+JLinkConnection {
 	//port: "99999999"
 
 	device: SAMA5D2 {


### PR DESCRIPTION
Should be JLinkConnection, not JlinkConnection.

Signed-off-by: Matt Wood <matt.wood@microchip.com>