### PR TITLE
sama5d2: Fix section numbers in datasheet references

### DIFF
--- a/doc/bootconfig_sama5d2.qdoc
+++ b/doc/bootconfig_sama5d2.qdoc
@@ -74,6 +74,6 @@ Configuration value can be either a number or a sequence of tokens separated by 
         DISABLE_MONITOR,
         SECURE_MODE,
     Tokens with a star (*) are selected by default if no token from the same line is provided (field value is 0).
-    Please refer to SAMA5D2 Datasheet section "15.4 Boot configuration" for information on boot settings.
+    Please refer to SAMA5D2 Datasheet section "16.5 Boot configuration" for information on boot settings.
 \endcode
 */

--- a/doc/cmdline.qdoc
+++ b/doc/cmdline.qdoc
@@ -248,7 +248,7 @@ The SAMA5D2 boot configuration can also be set using the command line via the
 boot config applet. The \e{readcfg} and \e{writecfg} commands can be used to
 get/set the Boot Sequence Register (BSCR) and the Boot Config Word either in
 BUREG registers or in FUSE. Please refer to SAMA5D2 Datasheet section
-"15.4 Boot configuration" for more details on the SAMA5D2 boot sequence.
+"16.5 Boot configuration" for more details on the SAMA5D2 boot sequence.
 
 To configure the boot to use BSCR/BUREG1 and boot on SPI0 IOSET2 or SDMMC0 and
 keep the default UART and JTAG settings, the following command can be used

--- a/src/plugins/device/sama5d2/SAMA5D2BootConfigApplet.qml
+++ b/src/plugins/device/sama5d2/SAMA5D2BootConfigApplet.qml
@@ -95,7 +95,7 @@ BootConfigApplet {
 			        "        DISABLE_MONITOR,",
 			        "        SECURE_MODE,",
 			        "    Tokens with a star (*) are selected by default if no token from the same line is provided (field value is 0).",
-			        "    Please refer to SAMA5D2 Datasheet section \"15.4 Boot configuration\" for information on boot settings."]
+			        "    Please refer to SAMA5D2 Datasheet section \"16.5 Boot configuration\" for information on boot settings."]
 		}
 	}
 }


### PR DESCRIPTION
According to revision history of the SAMA5D2 Series Datasheet, from
revision 11267E to DS60001476A a section “Safety and Security Features”
was added, so the numbering of later sections changed. The recent
revision is DS60001476C, references are updated to point to that one.

This was partly fixed with 65aab310d9f5 ("plugins/device/sama5d2: fix
datasheet section number for the NAND flash header"), but there are more
references on datasheet sections …