### PR TITLE
add KEYS_IN_FUSES to Boot Config Word options

### DIFF
--- a/doc/bootconfig_sama5d2.qdoc
+++ b/doc/bootconfig_sama5d2.qdoc
@@ -73,6 +73,7 @@ Configuration value can be either a number or a sequence of tokens separated by 
         DISABLE_BSCR,
         DISABLE_MONITOR,
         SECURE_MODE,
+        KEYS_IN_FUSES,
     Tokens with a star (*) are selected by default if no token from the same line is provided (field value is 0).
     Please refer to SAMA5D2 Datasheet section "16.5 Boot configuration" for information on boot settings.
 \endcode

--- a/src/plugins/device/sama5d2/sama5d2-bcw.js
+++ b/src/plugins/device/sama5d2/sama5d2-bcw.js
@@ -418,7 +418,8 @@ function fromText(text) {
 	             "QSPI_XIP_MODE",
 	             "DISABLE_BSCR",
 	             "DISABLE_MONITOR",
-	             "SECURE_MODE"]
+	             "SECURE_MODE",
+	             "KEYS_IN_FUSES"]
 	var values = [QSPI0_IOSET1, QSPI0_IOSET2,
 	              QSPI0_IOSET3, QSPI0_DISABLED,
 	              QSPI1_IOSET1, QSPI1_IOSET2,
@@ -439,7 +440,8 @@ function fromText(text) {
 	              QSPI_XIP_MODE,
 	              DISABLE_BSCR,
 	              DISABLE_MONITOR,
-	              SECURE_MODE]
+	              SECURE_MODE,
+	              KEYS_IN_FUSES]
 	var bcw = 0
 	for (var i = 0; i < entries.length; i++) {
 		var index = names.indexOf(entries[i].toUpperCase())


### PR DESCRIPTION
I wanted to burn the KEYS_IN_FUSES bit, but was unable to do so because it was missing here.  This adds the option when writing the BUREG or FUSE.